### PR TITLE
Declarative shaders

### DIFF
--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -42,15 +42,13 @@ setup f = do
   setDepthFunc Less
   setBlendFactors SourceAlpha OneMinusSourceAlpha
   setClearColour (Linear.V4 0 0 0 (1 :: Float))
+  matrix <- uniform "matrix"
+  time <- uniform "time"
+  let vertexShader = toShader (\ p -> pure (vertex { position = get matrix !* get p }) :: Shader Vertex)
+  let fragmentShader = get time + v4 0 0 1 (0.5 :: Float)
   program <- buildProgram [ Vertex vertexShader, Fragment fragmentShader ]
   array <- bindArray (rectVertices =<< renderingRects (renderView view :: Rendering Float (Size Float)) :: [Linear.V4 Float])
   setupIO (f (program, array))
-  where vertexShader = toShader $ \ p -> do
-          matrix <- uniform "matrix"
-          pure (vertex { position = get matrix !* get p })
-        fragmentShader = do
-          time <- uniform "time"
-          get time + v4 0 0 1 (0.5 :: Float)
 
 draw :: (GLProgram, GLArray Float) -> Draw ()
 draw (program, array) = do

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -21,7 +21,7 @@ import UI.Window
 
 main :: IO ()
 main = runWindow "UI" (\ swap ->
-  runSetup (setup (\ state -> forever (runDraw (uncurry draw state) >> swap))))
+  runSetup (setup (\ state -> forever (runDraw (draw state) >> swap))))
   `catch`
     (putStrLn . displayException :: SomeException -> IO ())
   `finally`
@@ -52,8 +52,8 @@ setup f = do
           time <- uniform "time"
           get time + v4 0 0 1 (0.5 :: Float)
 
-draw :: GLProgram -> GLArray Float -> Draw ()
-draw program array = do
+draw :: (GLProgram, GLArray Float) -> Draw ()
+draw (program, array) = do
   clear [ ColourBuffer, DepthBuffer ]
 
   useProgram program

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -56,8 +56,8 @@ draw matrix time program array = do
   useProgram program
 
   t <- drawIO (realToFrac . snd . (properFraction :: POSIXTime -> (Integer, POSIXTime)) <$> getPOSIXTime)
-  setUniform program time (Linear.V4 (sin (t * 2 * pi)) (cos (t * negate 2 * pi)) 0 0 :: Linear.V4 Float)
-  setUniform program matrix (orthographic 0 1024 0 768 (negate 1) 1 :: Linear.M44 Float)
+  setUniform program time (Linear.V4 (sin (t * 2 * pi)) (cos (t * negate 2 * pi)) 0 0)
+  setUniform program matrix (orthographic 0 1024 0 768 (negate 1) 1)
 
   bindVertexArray array
   drawArrays TriangleStrip 0 4

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -21,7 +21,7 @@ import UI.Window
 
 main :: IO ()
 main = runWindow "UI" (\ swap ->
-  runSetup (setup (\ matrix time state -> forever (runDraw (draw matrix time state) >> swap))))
+  runSetup (setup (\ matrix time program array -> forever (runDraw (draw matrix time program array) >> swap))))
   `catch`
     (putStrLn . displayException :: SomeException -> IO ())
   `finally`
@@ -35,7 +35,7 @@ rectVertices (Rect (Point x y) (Size w h)) =
   , Linear.V4 (x + w) (y + h) 0 1
   ]
 
-setup :: (Var (Shader (Linear.M44 Float)) -> Var (Shader (Linear.V4 Float)) -> (GLProgram, GLArray Float) -> IO a) -> Setup a
+setup :: (Var (Shader (Linear.M44 Float)) -> Var (Shader (Linear.V4 Float)) -> GLProgram -> GLArray Float -> IO a) -> Setup a
 setup f = do
   enable DepthTest
   enable Blending
@@ -48,10 +48,10 @@ setup f = do
   let fragmentShader = get time + v4 0 0 1 (0.5 :: Float)
   program <- buildProgram [ Vertex vertexShader, Fragment fragmentShader ]
   array <- bindArray (rectVertices =<< renderingRects (renderView view :: Rendering Float (Size Float)) :: [Linear.V4 Float])
-  setupIO (f matrix time (program, array))
+  setupIO (f matrix time program array)
 
-draw :: Var (Shader (Linear.M44 Float)) -> Var (Shader (Linear.V4 Float)) -> (GLProgram, GLArray Float) -> Draw ()
-draw matrix time (program, array) = do
+draw :: Var (Shader (Linear.M44 Float)) -> Var (Shader (Linear.V4 Float)) -> GLProgram -> GLArray Float -> Draw ()
+draw matrix time program array = do
   clear [ ColourBuffer, DepthBuffer ]
 
   useProgram program

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -39,7 +39,7 @@ setup :: ((GLProgram, GLArray Float) -> IO a) -> Setup a
 setup f = do
   enable DepthTest
   enable Blending
-  setDepthFunc Less
+  setDepthFunc Always
   setBlendFactors SourceAlpha OneMinusSourceAlpha
   setClearColour (Linear.V4 0 0 0 (1 :: Float))
   matrix <- uniform "matrix"

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -47,13 +47,10 @@ setup f = do
   setupIO (f (program, array))
   where vertexShader = toShader $ \ p -> do
           matrix <- uniform "matrix"
-          function "main" [] $
-            void $ set position (get matrix !* get p)
+          pure (vertex { position = get matrix !* get p })
         fragmentShader = do
           time <- uniform "time"
-          colour <- output "colour"
-          function "main" [] $
-            void $ set colour (get time + v4 0 0 1 (0.5 :: Float))
+          get time + v4 0 0 1 (0.5 :: Float)
 
 draw :: GLProgram -> GLArray Float -> Draw ()
 draw program array = do

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -46,11 +46,11 @@ setup f = do
   array <- bindArray (rectVertices =<< renderingRects (renderView view :: Rendering Float (Size Float)) :: [Linear.V4 Float])
   setupIO (f (program, array))
   where vertexShader = toShader $ \ p -> do
-          matrix <- uniform "matrix" :: Shader (Var (Shader (Linear.M44 Float)))
+          matrix <- uniform "matrix"
           function "main" [] $
             void $ set position (get matrix !* get p)
         fragmentShader = do
-          time <- uniform "time" :: Shader (Var (Shader (Linear.V4 Float)))
+          time <- uniform "time"
           colour <- output "colour"
           function "main" [] $
             void $ set colour (get time + v4 0 0 1 (0.5 :: Float))

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -45,9 +45,8 @@ setup f = do
   program <- buildProgram [ Vertex vertexShader, Fragment fragmentShader ]
   array <- bindArray (rectVertices =<< renderingRects (renderView view :: Rendering Float (Size Float)) :: [Linear.V4 Float])
   setupIO (f (program, array))
-  where vertexShader = do
+  where vertexShader = toShader $ \ p -> do
           matrix <- uniform "matrix" :: Shader (Var (Shader (Linear.M44 Float)))
-          p <- input "position" :: Shader (Var (Shader (Linear.V4 Float)))
           function "main" [] $
             void $ set position (get matrix !* get p)
         fragmentShader = do

--- a/gl/Main.hs
+++ b/gl/Main.hs
@@ -42,8 +42,8 @@ setup f = do
   setDepthFunc Always
   setBlendFactors SourceAlpha OneMinusSourceAlpha
   setClearColour (Linear.V4 0 0 0 (1 :: Float))
-  matrix <- uniform "matrix"
-  time <- uniform "time"
+  matrix <- uniform
+  time <- uniform
   let vertexShader = toShader (\ p -> pure (vertex { position = get matrix !* get p }) :: Shader Vertex)
   let fragmentShader = get time + v4 0 0 1 (0.5 :: Float)
   program <- buildProgram [ Vertex vertexShader, Fragment fragmentShader ]
@@ -57,8 +57,8 @@ draw (program, array) = do
   useProgram program
 
   t <- drawIO (realToFrac . snd . (properFraction :: POSIXTime -> (Integer, POSIXTime)) <$> getPOSIXTime)
-  setUniform program "time" (Linear.V4 (sin (t * 2 * pi)) (cos (t * negate 2 * pi)) 0 0 :: Linear.V4 Float)
-  setUniform program "matrix" (orthographic 0 1024 0 768 (negate 1) 1 :: Linear.M44 Float)
+  setUniform program "u1" (Linear.V4 (sin (t * 2 * pi)) (cos (t * negate 2 * pi)) 0 0 :: Linear.V4 Float)
+  setUniform program "u0" (orthographic 0 1024 0 768 (negate 1) 1 :: Linear.M44 Float)
 
   bindVertexArray array
   drawArrays TriangleStrip 0 4

--- a/src/GL/Draw.hs
+++ b/src/GL/Draw.hs
@@ -6,6 +6,7 @@ import Data.Bits
 import GL.Array
 import GL.Exception
 import GL.Program
+import GL.Shader
 import Graphics.GL.Core41
 import Prelude hiding (IO)
 
@@ -15,7 +16,7 @@ data Mode = Points | Lines | LineLoop | LineStrip | Triangles | TriangleStrip
 data DrawF a where
   Clear :: [Buffer] -> DrawF ()
   UseProgram :: GLProgram -> DrawF ()
-  SetUniform :: GLProgramUniform v => GLProgram -> String -> v -> DrawF ()
+  SetUniform :: GLProgramUniform v => GLProgram -> Var (Shader v) -> v -> DrawF ()
   BindVertexArray :: GLArray n -> DrawF ()
   DrawArrays :: Mode -> Int -> Int -> DrawF ()
   RunIO :: IO a -> DrawF a
@@ -29,7 +30,7 @@ clear = liftF . Clear
 useProgram :: GLProgram -> Draw ()
 useProgram = liftF . UseProgram
 
-setUniform :: GLProgramUniform v => GLProgram -> String -> v -> Draw ()
+setUniform :: GLProgramUniform v => GLProgram -> Var (Shader v) -> v -> Draw ()
 setUniform program var value = liftF (SetUniform program var value)
 
 bindVertexArray :: GLArray n -> Draw ()

--- a/src/GL/Program.hs
+++ b/src/GL/Program.hs
@@ -43,23 +43,23 @@ checkProgram = fmap GLProgram . checkStatus glGetProgramiv glGetProgramInfoLog O
 
 
 class GLProgramUniform t where
-  setUniformValue :: GLProgram -> String -> t -> IO ()
+  setUniformValue :: GLProgram -> Var (Shader t) -> t -> IO ()
 
 instance GLProgramUniform (Linear.V4 Float) where
-  setUniformValue program name (Linear.V4 x y z w)= do
-    location <- withCString name (glGetUniformLocation (unGLProgram program))
+  setUniformValue program var (Linear.V4 x y z w)= do
+    location <- withCString (varName var) (glGetUniformLocation (unGLProgram program))
     glProgramUniform4f (unGLProgram program) location x y z w
     checkGLError
 
 instance GLProgramUniform (Linear.V4 Double) where
-  setUniformValue program name (Linear.V4 x y z w)= do
-    location <- withCString name (glGetUniformLocation (unGLProgram program))
+  setUniformValue program var (Linear.V4 x y z w)= do
+    location <- withCString (varName var) (glGetUniformLocation (unGLProgram program))
     glProgramUniform4d (unGLProgram program) location x y z w
     checkGLError
 
 instance GLProgramUniform (Linear.M44 Float) where
-  setUniformValue program name matrix = do
-    location <- withCString name (glGetUniformLocation (unGLProgram program))
+  setUniformValue program var matrix = do
+    location <- withCString (varName var) (glGetUniformLocation (unGLProgram program))
     let fieldCount = sum (length <$> matrix)
     let fieldSize = sizeOf (0 :: Float)
     let byteCount = fieldCount * fieldSize

--- a/src/GL/Setup.hs
+++ b/src/GL/Setup.hs
@@ -13,7 +13,7 @@ import qualified Linear.V4 as Linear
 import Prelude hiding (IO)
 
 data Flag = DepthTest | Blending
-data Func = Less | LessEqual
+data Func = Less | LessEqual | Always
 data Factor
   = Zero
   | One
@@ -81,6 +81,7 @@ runSetup = iterFreerA $ \ run s -> case s of
     glDepthFunc $ case f of
       Less -> GL_LESS
       LessEqual -> GL_LEQUAL
+      Always -> GL_ALWAYS
     checkingGLError (run ())
   SetBlendFactors source destination -> do
     glBlendFunc (factor source) (factor destination)

--- a/src/GL/Setup.hs
+++ b/src/GL/Setup.hs
@@ -1,5 +1,22 @@
 {-# LANGUAGE DataKinds, GADTs, RankNTypes #-}
-module GL.Setup where
+module GL.Setup
+( Flag(..)
+, Func(..)
+, Factor(..)
+, Shader(..)
+, SetupF
+, Setup
+, enable
+, disable
+, setClearColour
+, setDepthFunc
+, setBlendFactors
+, bindArray
+, buildProgram
+, setupIO
+, uniform
+, runSetup
+) where
 
 import Control.Monad.Free.Freer
 import GL.Array

--- a/src/GL/Setup.hs
+++ b/src/GL/Setup.hs
@@ -71,26 +71,26 @@ uniform :: Shader.GLSLValue a => String -> Setup (Shader.Var (Shader.Shader a))
 uniform = liftF . Uniform
 
 runSetup :: Setup a -> IO a
-runSetup = iterFreerA $ \ rest s -> case s of
+runSetup = iterFreerA $ \ run s -> case s of
   Flag f b -> do
     toggle b $ case f of
       DepthTest -> GL_DEPTH_TEST
       Blending -> GL_BLEND
-    checkingGLError (rest ())
+    checkingGLError (run ())
   SetDepthFunc f -> do
     glDepthFunc $ case f of
       Less -> GL_LESS
-    checkingGLError (rest ())
+    checkingGLError (run ())
   SetBlendFactors source destination -> do
     glBlendFunc (factor source) (factor destination)
-    checkingGLError (rest ())
+    checkingGLError (run ())
   SetClearColour (Linear.V4 r g b a) -> do
     glClearColor (realToFrac r) (realToFrac g) (realToFrac b) (realToFrac a)
-    checkingGLError (rest ())
-  BindArray vertices -> withVertices vertices (checkingGLError . rest)
-  BuildProgram shaders -> withBuiltProgram (compileShader <$> shaders) (checkingGLError . rest)
-  RunIO io -> io >>= rest
-  Uniform s -> rest (Shader.Uniform s)
+    checkingGLError (run ())
+  BindArray vertices -> withVertices vertices (checkingGLError . run)
+  BuildProgram shaders -> withBuiltProgram (compileShader <$> shaders) (checkingGLError . run)
+  RunIO io -> io >>= run
+  Uniform s -> run (Shader.Uniform s)
   where toggle b = if b then glEnable else glDisable
         factor f = case f of
           Zero -> GL_ZERO

--- a/src/GL/Setup.hs
+++ b/src/GL/Setup.hs
@@ -13,7 +13,7 @@ import qualified Linear.V4 as Linear
 import Prelude hiding (IO)
 
 data Flag = DepthTest | Blending
-data Func = Less
+data Func = Less | LessEqual
 data Factor
   = Zero
   | One
@@ -80,6 +80,7 @@ runSetup = iterFreerA $ \ run s -> case s of
   SetDepthFunc f -> do
     glDepthFunc $ case f of
       Less -> GL_LESS
+      LessEqual -> GL_LEQUAL
     checkingGLError (run ())
   SetBlendFactors source destination -> do
     glBlendFunc (factor source) (factor destination)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -124,12 +124,12 @@ matrix !* column = Freer (Free pure (MulMV matrix column))
 
 elaborateShaderUniforms :: Shader a -> Shader a
 elaborateShaderUniforms shader = do
-  for_ uniformVars $ \ (UniformVar v) -> void (liftF (Bind v))
+  for_ (uniformVars shader) $ \ (UniformVar v) -> void (liftF (Bind v))
   shader
-  where uniformVars :: [UniformVar]
-        uniformVars = iterFreer uniformVarsAlgebra ([] <$ shader)
 
-        uniformVarsAlgebra :: (x -> [UniformVar]) -> ShaderF x -> [UniformVar]
+uniformVars :: Shader a -> [UniformVar]
+uniformVars = iterFreer uniformVarsAlgebra . fmap (const [])
+  where uniformVarsAlgebra :: (x -> [UniformVar]) -> ShaderF x -> [UniformVar]
         uniformVarsAlgebra run s = case s of
           Get var -> case var of
             Uniform _ -> pure (UniformVar var)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -132,9 +132,7 @@ uniformVars :: Shader a -> [UniformVar]
 uniformVars = iterFreer uniformVarsAlgebra . fmap (const [])
   where uniformVarsAlgebra :: (x -> [UniformVar]) -> ShaderF x -> [UniformVar]
         uniformVarsAlgebra run s = case s of
-          Get var -> case var of
-            Uniform _ -> pure (UniformVar var)
-            _ -> []
+          Get var@(Uniform _) -> [ UniformVar var ]
           _ -> foldMap run s
 
 elaborateVertexShader :: Shader Vertex -> Shader ()

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -122,7 +122,7 @@ matrix !* column = Freer (Free pure (MulMV matrix column))
 -- Variables
 
 position :: Var (Shader (Linear.V4 Float))
-position = In "gl_Position"
+position = Out "gl_Position"
 
 
 -- Compilation

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -326,3 +326,7 @@ instance GLSLValue a => GLSLValue (Linear.V4 a) where
   showsGLSLType _ = showsGLSLVecType (Proxy :: Proxy a)
   showsGLSLVecType _ = showString "mat4"
   showsGLSLValue v = showsGLSLVecType (Proxy :: Proxy a) . showParen True (foldr (.) id (intersperse (showString ", ") (showsGLSLValue <$> toList v)))
+
+instance IsShader (Shader a) where
+  type ShaderResult (Shader a) = a
+  toShader = id

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -139,16 +139,15 @@ uniformVars = iterFreer uniformVarsAlgebra . fmap (const [])
           _ -> foldMap run s
 
 elaborateVertexShader :: Shader Vertex -> Shader ()
-elaborateVertexShader shader = do
-  Vertex pos _ _ <- elaborateShaderUniforms shader
+elaborateVertexShader shader = elaborateShaderUniforms $ do
+  Vertex pos _ _ <- shader
   function "main" [] . void $ set gl_Position pos
   where gl_Position = Out "gl_Position"
 
 elaborateShader :: GLSLValue a => Shader a -> Shader ()
-elaborateShader shader = do
-  let s = elaborateShaderUniforms shader
+elaborateShader shader = elaborateShaderUniforms $ do
   out <- output "result"
-  function "main" [] . void $ set out s
+  function "main" [] . void $ set out shader
 
 
 -- Compilation

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -37,9 +37,9 @@ import qualified Linear.V4 as Linear
 import Prelude hiding (IO)
 
 data Var a where
-  In :: GLSLValue a => String -> Var a
-  Out :: GLSLValue a => String -> Var a
-  Uniform :: GLSLValue a => String -> Var a
+  In :: GLSLValue a => String -> Var (Shader a)
+  Out :: GLSLValue a => String -> Var (Shader a)
+  Uniform :: GLSLValue a => String -> Var (Shader a)
 
 varName :: Var a -> String
 varName (In s) = s
@@ -150,6 +150,10 @@ elaborateShader shader = do
 
 
 -- Compilation
+
+data UniformVar where
+  UniformVar :: GLSLValue a => Var (Shader a) -> UniformVar
+
 
 toGLSL :: GLSLValue a => Shader a -> String
 toGLSL = ($ "") . (showString "#version 410\n" .) . iterFreer toGLSLAlgebra . fmap showsGLSLValue

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -5,12 +5,8 @@ module GL.Shader
 , ShaderF
 , Vertex(position, pointSize, clipDistance)
 , vertex
-, set
 , get
 , uniform
-, input
-, output
-, function
 , v4
 , (!*)
 , elaborateVertexShader

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -163,7 +163,7 @@ toGLSLAlgebra run shader = case shader of
     <> showBrace True (nl <> sp <> sp <> run body)
 
   Get v -> case v of
-    v'@(Uniform _) -> let out = var v in out { uniforms = UniformVar v' : uniforms out }
+    Uniform _ -> let out = var v in out { uniforms = UniformVar v : uniforms out }
     _ -> var v
   Set v value -> var v <> sp <> showChar '=' <> sp <> run value <> showChar ';' <> nl
 

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -369,7 +369,7 @@ instance IsShader (Shader a) where
 instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
   type ShaderResult (Var (Shader a) -> b) = ShaderResult b
   toShader' f i = do
-    var <- input ('v' : show i)
+    var <- input ('i' : show i)
     toShader' (f var) (succ i)
 
 deriving instance Show UniformVar

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DefaultSignatures, FlexibleInstances, GADTs, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeFamilies #-}
 module GL.Shader
 ( Var(Uniform)
+, varName
 , Shader
 , ShaderF
 , Vertex(position, pointSize, clipDistance)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -12,6 +12,7 @@ module GL.Shader
 , v4
 , (!*)
 , position
+, elaborateShader
 , toGLSL
 , GLShader(..)
 , withCompiledShaders
@@ -21,6 +22,7 @@ module GL.Shader
 ) where
 
 import Control.Exception
+import Control.Monad
 import Control.Monad.Free.Freer
 import Data.Foldable (toList)
 import Data.Functor.Classes
@@ -123,6 +125,14 @@ matrix !* column = Freer (Free pure (MulMV matrix column))
 
 position :: Var (Shader (Linear.V4 Float))
 position = Out "gl_Position"
+
+
+-- Elaboration
+
+elaborateShader :: GLSLValue a => Shader a -> Shader ()
+elaborateShader shader = do
+  out <- output "result"
+  function "main" [] . void $ set out shader
 
 
 -- Compilation

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -23,7 +23,7 @@ import Control.Monad
 import Control.Monad.Free.Freer
 import Data.Foldable (toList, for_)
 import Data.Functor.Classes
-import Data.List (intersperse, unionBy)
+import Data.List (intersperse)
 import Data.Monoid ((<>))
 import Data.Proxy
 import Foreign.C.String
@@ -392,9 +392,4 @@ instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
 
 instance Monoid CompilerState where
   mempty = CompilerState [] id
-  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (unionBy eqVars u1 u2) (s1 . s2)
-    where eqVars (UniformVar v1) (UniformVar v2) = case (v1, v2) of
-            (Uniform s1, Uniform s2) -> s1 == s2
-            (In s1, In s2) -> s1 == s2
-            (Out s1, Out s2) -> s1 == s2
-            _ -> False
+  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (mappend u1 u2) (s1 . s2)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -17,6 +17,7 @@ module GL.Shader
 , withCompiledShaders
 , GLSLValue(..)
 , IsShader
+, toShader
 ) where
 
 import Control.Exception
@@ -215,6 +216,9 @@ class IsShader t where
   type ShaderResult t :: *
 
   toShader' :: t -> Int -> Shader (ShaderResult t)
+
+toShader :: IsShader t => t -> Shader (ShaderResult t)
+toShader = flip toShader' 0
 
 
 -- Instances

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -132,8 +132,10 @@ uniformVars :: Shader a -> [UniformVar]
 uniformVars = iterFreer uniformVarsAlgebra . fmap (const [])
   where uniformVarsAlgebra :: (x -> [UniformVar]) -> ShaderF x -> [UniformVar]
         uniformVarsAlgebra run s = case s of
+          Bind v -> run v
           Get var@(Uniform _) -> [ UniformVar var ]
           Set var@(Uniform _) value -> UniformVar var : run value
+          MulMV a b -> uniformVars a ++ uniformVars b
           _ -> foldMap run s
 
 elaborateVertexShader :: Shader Vertex -> Shader ()

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -133,6 +133,7 @@ uniformVars = iterFreer uniformVarsAlgebra . fmap (const [])
   where uniformVarsAlgebra :: (x -> [UniformVar]) -> ShaderF x -> [UniformVar]
         uniformVarsAlgebra run s = case s of
           Get var@(Uniform _) -> [ UniformVar var ]
+          Set var@(Uniform _) value -> UniformVar var : run value
           _ -> foldMap run s
 
 elaborateVertexShader :: Shader Vertex -> Shader ()

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -97,6 +97,9 @@ vertex :: Vertex
 vertex = Vertex (pure (Linear.V4 0 0 0 0)) (pure 0) (pure [])
 
 
+uniform :: GLSLValue a => String -> Shader (Var (Shader a))
+uniform = liftF . Bind . Uniform
+
 input :: GLSLValue a => String -> Shader (Var (Shader a))
 input = liftF . Bind . In
 

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -157,6 +157,10 @@ data UniformVar where
 
 data CompilerState = CompilerState { uniforms :: [UniformVar], program :: ShowS }
 
+instance Monoid CompilerState where
+  mempty = CompilerState [] id
+  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (mappend u1 u2) (s1 . s2)
+
 
 toGLSL :: GLSLValue a => Shader a -> String
 toGLSL = ($ "") . (showString "#version 410\n" .) . program . iterFreer toGLSLAlgebra . fmap (CompilerState [] . showsGLSLValue)
@@ -384,7 +388,3 @@ instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
   toShader' f i = do
     var <- input ('v' : show i)
     toShader' (f var) (succ i)
-
-instance Monoid CompilerState where
-  mempty = CompilerState [] id
-  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (mappend u1 u2) (s1 . s2)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -214,7 +214,7 @@ class GLSLValue v where
 class IsShader t where
   type ShaderResult t :: *
 
-  toShader :: t -> Shader (ShaderResult t)
+  toShader :: t -> Int -> Shader (ShaderResult t)
 
 
 -- Instances
@@ -329,10 +329,10 @@ instance GLSLValue a => GLSLValue (Linear.V4 a) where
 
 instance IsShader (Shader a) where
   type ShaderResult (Shader a) = a
-  toShader = id
+  toShader = const
 
 instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
   type ShaderResult (Var (Shader a) -> b) = ShaderResult b
-  toShader f = do
-    var <- input ""
-    toShader (f var)
+  toShader f i = do
+    var <- input ('v' : show i)
+    toShader (f var) (succ i)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -373,3 +373,5 @@ instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
   toShader' f i = do
     var <- input ('v' : show i)
     toShader' (f var) (succ i)
+
+deriving instance Show UniformVar

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -180,7 +180,7 @@ toGLSLAlgebra run shader = case shader of
   Abs a -> fun "abs" a
   Signum a -> fun "sign" a
 
-  MulMV matrix column -> foldMap run matrix . showChar '*' . run column
+  MulMV matrix column -> foldMap run matrix . sp . showChar '*' . sp . run column
 
   Sin a -> fun "sin" a
   Cos a -> fun "cos" a

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -69,7 +69,7 @@ data ShaderF a where
   Signum :: a -> ShaderF a
 
   -- Matrix arithmetic
-  MulMV :: Linear.V4 a -> a -> ShaderF a
+  MulMV :: Linear.M44 a -> Linear.V4 a -> ShaderF (Linear.V4 a)
 
   -- Trigonometric
   Sin :: a -> ShaderF a

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -118,7 +118,7 @@ v4 x y z w = liftF (V4 (Linear.V4 x y z w))
 infixl 7 !*
 
 (!*) :: Shader (Linear.M44 a) -> Shader (Linear.V4 a) -> Shader (Linear.V4 a)
-matrix !* column = Freer (Free pure (MulMV matrix column))
+matrix !* column = liftF (MulMV matrix column)
 
 
 -- Elaboration

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -19,7 +19,7 @@ module GL.Shader
 ) where
 
 import Control.Exception
-import Control.Monad
+import Control.Monad (void)
 import Control.Monad.Free.Freer
 import Data.Foldable (toList, for_)
 import Data.Functor.Classes

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DefaultSignatures, FlexibleInstances, GADTs, RankNTypes, ScopedTypeVariables, StandaloneDeriving #-}
+{-# LANGUAGE DefaultSignatures, FlexibleInstances, GADTs, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeFamilies #-}
 module GL.Shader
 ( Var
 , Shader
@@ -16,6 +16,7 @@ module GL.Shader
 , GLShader(..)
 , withCompiledShaders
 , GLSLValue(..)
+, IsShader(..)
 ) where
 
 import Control.Exception
@@ -209,6 +210,11 @@ class GLSLValue v where
   showsGLSLValue :: v -> ShowS
   default showsGLSLValue :: Show v => v -> ShowS
   showsGLSLValue = shows
+
+class IsShader t where
+  type ShaderResult t :: *
+
+  toShader :: t -> Shader (ShaderResult t)
 
 
 -- Instances

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -96,9 +96,6 @@ vertex :: Vertex
 vertex = Vertex (pure (Linear.V4 0 0 0 0)) (pure 0) (pure [])
 
 
-uniform :: GLSLValue a => String -> Shader (Var (Shader a))
-uniform = liftF . Bind . Uniform
-
 input :: GLSLValue a => String -> Shader (Var (Shader a))
 input = liftF . Bind . In
 

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -69,7 +69,7 @@ data ShaderF a where
   Signum :: a -> ShaderF a
 
   -- Matrix arithmetic
-  MulMV :: Linear.M44 a -> Linear.V4 a -> ShaderF (Linear.V4 a)
+  MulMV :: Linear.V4 a -> a -> ShaderF a
 
   -- Trigonometric
   Sin :: a -> ShaderF a

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -91,6 +91,7 @@ data ShaderF a where
 type Shader = Freer ShaderF
 
 data Vertex = Vertex { position :: Shader (Linear.V4 Float), pointSize :: Shader Float, clipDistance :: Shader [Float] }
+  deriving Show
 
 vertex :: Vertex
 vertex = Vertex (pure (Linear.V4 0 0 0 0)) (pure 0) (pure [])

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -16,7 +16,7 @@ module GL.Shader
 , GLShader(..)
 , withCompiledShaders
 , GLSLValue(..)
-, IsShader(..)
+, IsShader
 ) where
 
 import Control.Exception
@@ -214,7 +214,7 @@ class GLSLValue v where
 class IsShader t where
   type ShaderResult t :: *
 
-  toShader :: t -> Int -> Shader (ShaderResult t)
+  toShader' :: t -> Int -> Shader (ShaderResult t)
 
 
 -- Instances
@@ -329,10 +329,10 @@ instance GLSLValue a => GLSLValue (Linear.V4 a) where
 
 instance IsShader (Shader a) where
   type ShaderResult (Shader a) = a
-  toShader = const
+  toShader' = const
 
 instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
   type ShaderResult (Var (Shader a) -> b) = ShaderResult b
-  toShader f i = do
+  toShader' f i = do
     var <- input ('v' : show i)
-    toShader (f var) (succ i)
+    toShader' (f var) (succ i)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -142,10 +142,6 @@ data UniformVar where
 
 data CompilerState = CompilerState { uniforms :: [UniformVar], program :: ShowS }
 
-instance Monoid CompilerState where
-  mempty = CompilerState [] id
-  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (mappend u1 u2) (s1 . s2)
-
 
 toGLSL :: GLSLValue a => Shader a -> String
 toGLSL = ($ "") . (showString "#version 410\n" .) . program . iterFreer toGLSLAlgebra . fmap (CompilerState [] . showsGLSLValue)
@@ -373,3 +369,7 @@ instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
   toShader' f i = do
     var <- input ('v' : show i)
     toShader' (f var) (succ i)
+
+instance Monoid CompilerState where
+  mempty = CompilerState [] id
+  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (mappend u1 u2) (s1 . s2)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -97,9 +97,6 @@ vertex :: Vertex
 vertex = Vertex (pure (Linear.V4 0 0 0 0)) (pure 0) (pure [])
 
 
-uniform :: GLSLValue a => String -> Shader (Var (Shader a))
-uniform = liftF . Bind . Uniform
-
 input :: GLSLValue a => String -> Shader (Var (Shader a))
 input = liftF . Bind . In
 

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -1,12 +1,11 @@
 {-# LANGUAGE DefaultSignatures, FlexibleInstances, GADTs, RankNTypes, ScopedTypeVariables, StandaloneDeriving, TypeFamilies #-}
 module GL.Shader
-( Var
+( Var(Uniform)
 , Shader
 , ShaderF
 , Vertex(position, pointSize, clipDistance)
 , vertex
 , get
-, uniform
 , v4
 , (!*)
 , elaborateVertexShader

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -340,7 +340,7 @@ instance Show1 ShaderF where
 instance GLSLValue () where
   showsGLSLType _ = showString "void"
   showsGLSLVecType _ = showString "void"
-  showsGLSLValue = shows
+  showsGLSLValue = const id
 
 instance GLSLValue Float where
   showsGLSLType _ = showString "float"

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -23,7 +23,7 @@ import Control.Monad
 import Control.Monad.Free.Freer
 import Data.Foldable (toList)
 import Data.Functor.Classes
-import Data.List (intersperse)
+import Data.List (intersperse, unionBy)
 import Data.Monoid ((<>))
 import Data.Proxy
 import Foreign.C.String
@@ -377,4 +377,9 @@ instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
 
 instance Monoid CompilerState where
   mempty = CompilerState [] id
-  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (mappend u1 u2) (s1 . s2)
+  mappend (CompilerState u1 s1) (CompilerState u2 s2) = CompilerState (unionBy eqVars u1 u2) (s1 . s2)
+    where eqVars (UniformVar v1) (UniformVar v2) = case (v1, v2) of
+            (Uniform s1, Uniform s2) -> s1 == s2
+            (In s1, In s2) -> s1 == s2
+            (Out s1, Out s2) -> s1 == s2
+            _ -> False

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -170,7 +170,7 @@ toGLSLAlgebra run shader = case shader of
   Get v -> var v
   Set v value -> var v . sp . showChar '=' . sp . run value . showChar ';' . nl
 
-  V4 v -> showsGLSLValue v
+  V4 v -> showsGLSLValue v . run v
 
   Add a b -> op '+' a b
   Sub a b -> op '-' a b

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -161,17 +161,12 @@ data CompilerState = CompilerState { uniforms :: [UniformVar], program :: ShowS 
 toGLSL :: GLSLValue a => Shader a -> String
 toGLSL = ($ "") . (showString "#version 410\n" .) . program . iterFreer toGLSLAlgebra . fmap (CompilerState [] . showsGLSLValue)
 
-showVarDeclaration :: forall a. GLSLValue a => Var (Shader a) -> ShowS
-showVarDeclaration v = case v of
-  Uniform s -> showString "uniform" <> sp <> showsGLSLType (Proxy :: Proxy a) <> sp <> showString s <> showChar ';' <> nl
-  In s -> showString "in" <> sp <> showsGLSLType (Proxy :: Proxy a) <> sp <> showString s <> showChar ';' <> nl
-  Out s -> showString "out" <> sp <> showsGLSLType (Proxy :: Proxy a) <> sp <> showString s <> showChar ';' <> nl
-  where sp = showChar ' '
-        nl = showChar '\n'
-
 toGLSLAlgebra :: forall x. (x -> CompilerState) -> ShaderF x -> CompilerState
 toGLSLAlgebra run shader = case shader of
-  Bind var -> state (showVarDeclaration var) <> run var
+  Bind var -> case var of
+    Uniform s -> showString "uniform" <> sp <> showsGLSLType (Proxy :: Proxy x) <> sp <> showString s <> showChar ';' <> nl <> run var
+    In s -> showString "in" <> sp <> showsGLSLType (Proxy :: Proxy x) <> sp <> showString s <> showChar ';' <> nl <> run var
+    Out s -> showString "out" <> sp <> showsGLSLType (Proxy :: Proxy x) <> sp <> showString s <> showChar ';' <> nl <> run var
 
   Function name args body ->
     showsGLSLType (Proxy :: Proxy x) <> sp <> showString name

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -180,7 +180,7 @@ toGLSLAlgebra run shader = case shader of
   Abs a -> fun "abs" a
   Signum a -> fun "sign" a
 
-  MulMV matrix column -> foldMap run matrix . sp . showChar '*' . sp . run column
+  MulMV matrix column -> foldMap run matrix . showChar '*' . run column
 
   Sin a -> fun "sin" a
   Cos a -> fun "cos" a

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -160,10 +160,7 @@ toGLSL = ($ "") . (showString "#version 410\n" .) . iterFreer toGLSLAlgebra . fm
 
 toGLSLAlgebra :: forall x. (x -> ShowS) -> ShaderF x -> ShowS
 toGLSLAlgebra run shader = case shader of
-  Bind var -> case var of
-    Uniform s -> showString "uniform" . sp . showsGLSLType (Proxy :: Proxy x) . sp . showString s . showChar ';' . nl . run var
-    In s -> showString "in" . sp . showsGLSLType (Proxy :: Proxy x) . sp . showString s . showChar ';' . nl . run var
-    Out s -> showString "out" . sp . showsGLSLType (Proxy :: Proxy x) . sp . showString s . showChar ';' . nl . run var
+  Bind var -> showVarDeclQualifier var . sp . showsGLSLType (Proxy :: Proxy x) . sp . showString (varName var) . showChar ';' . nl . run var
 
   Function name args body ->
     showsGLSLType (Proxy :: Proxy x) . sp . showString name
@@ -209,6 +206,10 @@ toGLSLAlgebra run shader = case shader of
         vec v = showString "vec" . shows (length v) . showParen True (foldr (.) id (run <$> v))
         recur = (iterFreer toGLSLAlgebra .) . fmap
         showBrace c b = if c then showChar '{' . b . showChar '}' else b
+        showVarDeclQualifier var = showString $ case var of
+          Uniform _ -> "uniform"
+          In _ -> "in"
+          Out _ -> "out"
 
 
 newtype GLShader = GLShader { unGLShader :: GLuint }

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -19,7 +19,7 @@ module GL.Shader
 ) where
 
 import Control.Exception
-import Control.Monad (join, void)
+import Control.Monad
 import Control.Monad.Free.Freer
 import Data.Foldable (toList, for_)
 import Data.Functor.Classes
@@ -69,7 +69,7 @@ data ShaderF a where
   Signum :: a -> ShaderF a
 
   -- Matrix arithmetic
-  MulMV :: Linear.M44 a -> Linear.V4 a -> ShaderF (Linear.V4 a)
+  MulMV :: Shader (Linear.V4 a) -> Shader a -> ShaderF a
 
   -- Trigonometric
   Sin :: a -> ShaderF a
@@ -118,7 +118,7 @@ v4 x y z w = liftF (V4 (Linear.V4 x y z w))
 infixl 7 !*
 
 (!*) :: Shader (Linear.M44 a) -> Shader (Linear.V4 a) -> Shader (Linear.V4 a)
-matrix !* column = join $ (liftF .) . MulMV <$> matrix <*> column
+matrix !* column = liftF (MulMV matrix column)
 
 
 -- Elaboration
@@ -135,6 +135,7 @@ uniformVars = iterFreer uniformVarsAlgebra . fmap (const [])
           Bind v -> run v
           Get var@(Uniform _) -> [ UniformVar var ]
           Set var@(Uniform _) value -> UniformVar var : run value
+          MulMV a b -> uniformVars a ++ uniformVars b
           _ -> foldMap run s
 
 elaborateVertexShader :: Shader Vertex -> Shader ()
@@ -180,7 +181,7 @@ toGLSLAlgebra run shader = case shader of
   Abs a -> fun "abs" a
   Signum a -> fun "sign" a
 
-  MulMV matrix column -> foldMap run matrix . showChar '*' . run column
+  MulMV matrix column -> recur vec matrix . showChar '*' . recur run column
 
   Sin a -> fun "sin" a
   Cos a -> fun "cos" a
@@ -203,6 +204,8 @@ toGLSLAlgebra run shader = case shader of
         var = showString . varName
         sp = showChar ' '
         nl = showChar '\n'
+        vec v = showString "vec" . shows (length v) . showParen True (foldr (.) id (run <$> v))
+        recur = (iterFreer toGLSLAlgebra .) . fmap
         showBrace c b = if c then showChar '{' . b . showChar '}' else b
         showVarDeclQualifier var = showString $ case var of
           Uniform _ -> "uniform"
@@ -313,7 +316,7 @@ instance Show1 ShaderF where
     Abs a -> showsUnaryWith sp "Abs" d a
     Signum a -> showsUnaryWith sp "Signum" d a
 
-    MulMV a b -> showsBinaryWith (liftShowsPrec sp sl) sp "MulMV" d a b
+    MulMV a b -> showsBinaryWith (liftShowsPrec (liftShowsPrec sp sl) (liftShowList sp sl)) (liftShowsPrec sp sl) "MulMV" d a b
 
     Sin a -> showsUnaryWith sp "Sin" d a
     Cos a -> showsUnaryWith sp "Cos" d a

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -330,3 +330,9 @@ instance GLSLValue a => GLSLValue (Linear.V4 a) where
 instance IsShader (Shader a) where
   type ShaderResult (Shader a) = a
   toShader = id
+
+instance (GLSLValue a, IsShader b) => IsShader (Var (Shader a) -> b) where
+  type ShaderResult (Var (Shader a) -> b) = ShaderResult b
+  toShader f = do
+    var <- input ""
+    toShader (f var)

--- a/src/GL/Shader.hs
+++ b/src/GL/Shader.hs
@@ -178,7 +178,7 @@ toGLSLAlgebra run shader = case shader of
     <> showBrace True (nl <> sp <> sp <> run body)
 
   Get v -> case v of
-    Uniform _ -> let out = var v in out { uniforms = UniformVar v : uniforms out }
+    v'@(Uniform _) -> let out = var v in out { uniforms = UniformVar v' : uniforms out }
     _ -> var v
   Set v value -> var v <> sp <> showChar '=' <> sp <> run value <> showChar ';' <> nl
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -37,6 +37,9 @@ resolver: nightly-2016-09-10
 # will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
+- location:
+    git: https://github.com/joshvera/effects.git
+    commit: de7961dd6884565dfc9e45309a0c56539a00af17
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
 extra-deps:

--- a/test/GL/Shader/Spec.hs
+++ b/test/GL/Shader/Spec.hs
@@ -1,6 +1,5 @@
 module GL.Shader.Spec where
 
-import Control.Monad (void)
 import Data.List (intercalate)
 import GL.Shader
 import Linear.V4 as Linear
@@ -10,10 +9,7 @@ spec :: Spec
 spec = do
   describe "toGLSL" $ do
     it "compiles constants" $
-      toGLSL (do
-        fragColour <- bind "fragColour"
-        function "main" [] $
-          void $ set fragColour (v4 1 0 0 1.0 :: Shader (Linear.V4 Float))) `shouldBe` intercalate "\n"
+      toGLSL (elaborateShader (v4 1 0 0 1.0 :: Shader (Linear.V4 Float))) `shouldBe` intercalate "\n"
         [ "#version 410"
         , "out vec4 fragColour;"
         , "void main(void) {"

--- a/test/GL/Shader/Spec.hs
+++ b/test/GL/Shader/Spec.hs
@@ -11,8 +11,8 @@ spec = do
     it "compiles constants" $
       toGLSL (elaborateShader (v4 1 0 0 1.0 :: Shader (Linear.V4 Float))) `shouldBe` intercalate "\n"
         [ "#version 410"
-        , "out vec4 fragColour;"
+        , "out vec4 result;"
         , "void main(void) {"
-        , "  fragColour = vec4(1.0, 0.0, 0.0, 1.0);"
+        , "  result = vec4(1.0, 0.0, 0.0, 1.0);"
         , "}"
         ]

--- a/ui-effects.cabal
+++ b/ui-effects.cabal
@@ -33,6 +33,7 @@ library
                      , UI.Window
   build-depends:       base >= 4.7 && < 5
                      , comonad
+                     , effects
                      , free
                      , gl
                      , linear


### PR DESCRIPTION
Taking a stab at #12 by (among other things) elaboration.

- [x] Infer input variables from function parameters.
- [x] Move uniform declarations into `Setup`.
- [x] Vertex shaders should be typed as `Shader Vertex`, and elaborate to a shader setting the appropriate global(s).
- [x] `Shader a` should elaborate to an output set to the value of the shader.
- [x] 🔥 `function` (or at least its export).
- [x] 🔥 the exports of the `uniform`, `input`, `output`, and `set` smart constructors.
- [x] Declare uniforms defined in `Setup` in the corresponding shaders.
- [x] 🔥 the explicit name passed to `uniform`.

Fixes #12.