### PR TITLE
Layout adjacency

### DIFF
--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GADTs #-}
+{-# LANGUAGE FlexibleInstances, GADTs, RecordWildCards #-}
 module UI.Drawing
 ( Shape(..)
 , Colour(..)
@@ -74,23 +74,23 @@ drawingCoalgebra (state, drawing) = Cofree state id $ case runFreer drawing of
     Text size string -> Free ((,) state . runF) (Text size string)
     Clip size child -> Free id (Clip size (state, runF child))
 
-renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Alignment, Point a, Size (Maybe a), Rendering a (Size a))
-renderingCoalgebra (alignment, offset, maxSize, rendering) = Cofree (FittingState alignment offset maxSize) id $ case runFreer rendering of
+renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (FittingState a, Rendering a (Size a))
+renderingCoalgebra (state@FittingState{..}, rendering) = Cofree state id $ case runFreer rendering of
   Pure size -> Pure size
   Free runF rendering -> case rendering of
     InL drawing -> case drawing of
-      Text size string -> Free ((,,,) alignment offset maxSize . runF) (InL (Text size string))
-      Clip size child -> Free id (InL (Clip size (alignment, offset, maxSize, runF child)))
+      Text size string -> Free ((,) state . runF) (InL (Text size string))
+      Clip size child -> Free id (InL (Clip size (state, runF child)))
     InR layout -> case layout of
-      Inset by child -> Free id (InR (Inset by (alignment, addSizeToPoint offset by, subtractSize maxSize (2 * by), runF child)))
-      Offset by child -> Free id (InR (Offset by (alignment, liftA2 (+) offset by, subtractSize maxSize (pointSize by), runF child)))
-      GetMaxSize -> Free ((,,,) alignment offset maxSize . runF) (InR GetMaxSize)
-      Align alignment child -> Free id (InR (Align alignment (alignment, offset, maxSize, runF child)))
+      Inset by child -> Free id (InR (Inset by (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by)), runF child)))
+      Offset by child -> Free id (InR (Offset by (FittingState alignment (liftA2 (+) origin by) (subtractSize maxSize (pointSize by)), runF child)))
+      GetMaxSize -> Free ((,) state . runF) (InR GetMaxSize)
+      Align alignment child -> Free id (InR (Align alignment (state, runF child)))
   where subtractSize maxSize size = liftA2 (-) <$> maxSize <*> (Just <$> size)
         addSizeToPoint point (Size w h) = liftA2 (+) point (Point w h)
 
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]
-renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . (,,,) Full (pure 0) (pure Nothing)
+renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . (,) (FittingState Full (pure 0) (pure Nothing))
 
 
 -- Instances

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -67,12 +67,12 @@ renderingRectAlgebra (Cofree a@(FittingState _ origin _) runC r) = case runC <$>
     InL drawing -> drawingRectAlgebra (Cofree a id (Free runF drawing))
     InR layout -> fromMaybe (Rect (pure 0) (pure 0)) (layoutAlgebra (Just <$> Cofree a id (Free runF layout)))
 
-drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Alignment, Point a, Size (Maybe a), Drawing a (Size a))
-drawingCoalgebra (alignment, offset, maxSize, drawing) = Cofree (FittingState alignment offset maxSize) id $ case runFreer drawing of
+drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (FittingState a, Drawing a (Size a))
+drawingCoalgebra (state, drawing) = Cofree state id $ case runFreer drawing of
   Pure size -> Pure size
   Free runF drawing -> case drawing of
-    Text size string -> Free ((,,,) alignment offset maxSize . runF) (Text size string)
-    Clip size child -> Free id (Clip size (alignment, offset, maxSize, runF child))
+    Text size string -> Free ((,) state . runF) (Text size string)
+    Clip size child -> Free id (Clip size (state, runF child))
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Alignment, Point a, Size (Maybe a), Rendering a (Size a))
 renderingCoalgebra (alignment, offset, maxSize, rendering) = Cofree (FittingState alignment offset maxSize) id $ case runFreer rendering of

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -51,7 +51,7 @@ clip size = wrap . Clip size
 
 
 drawingRectAlgebra :: Real a => Algebra (Fitting (DrawingF a) a) (Rect a)
-drawingRectAlgebra (Cofree (_, origin, _) runC r) = Rect origin $ case r of
+drawingRectAlgebra (Cofree (FittingState _ origin _) runC r) = Rect origin $ case r of
   Pure size -> size
   Free runF drawing -> case drawing of
     Text maxSize s -> size (runC (runF (measureText (width maxSize) s)))
@@ -61,21 +61,21 @@ drawingRectanglesAlgebra :: Real a => Algebra (Fitting (DrawingF a) a) [Rect a]
 drawingRectanglesAlgebra = collect drawingRectAlgebra
 
 renderingRectAlgebra :: Real a => Algebra (Fitting (RenderingF a) a) (Rect a)
-renderingRectAlgebra (Cofree a@(_, origin, _) runC r) = case runC <$> r of
+renderingRectAlgebra (Cofree a@(FittingState _ origin _) runC r) = case runC <$> r of
   Pure size -> Rect origin size
   Free runF sum -> case sum of
     InL drawing -> drawingRectAlgebra (Cofree a id (Free runF drawing))
     InR layout -> fromMaybe (Rect (pure 0) (pure 0)) (layoutAlgebra (Just <$> Cofree a id (Free runF layout)))
 
 drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Alignment, Point a, Size (Maybe a), Drawing a (Size a))
-drawingCoalgebra (alignment, offset, maxSize, drawing) = Cofree (alignment, offset, maxSize) id $ case runFreer drawing of
+drawingCoalgebra (alignment, offset, maxSize, drawing) = Cofree (FittingState alignment offset maxSize) id $ case runFreer drawing of
   Pure size -> Pure size
   Free runF drawing -> case drawing of
     Text size string -> Free ((,,,) alignment offset maxSize . runF) (Text size string)
     Clip size child -> Free id (Clip size (alignment, offset, maxSize, runF child))
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Alignment, Point a, Size (Maybe a), Rendering a (Size a))
-renderingCoalgebra (alignment, offset, maxSize, rendering) = Cofree (alignment, offset, maxSize) id $ case runFreer rendering of
+renderingCoalgebra (alignment, offset, maxSize, rendering) = Cofree (FittingState alignment offset maxSize) id $ case runFreer rendering of
   Pure size -> Pure size
   Free runF rendering -> case rendering of
     InL drawing -> case drawing of

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -87,7 +87,7 @@ renderingCoalgebra (state@FittingState{..}, rendering) = Cofree state id $ case 
       GetMaxSize -> Free ((,) state . runF) (InR GetMaxSize)
       Align alignment child -> Free id (InR (Align alignment (state { alignment = alignment }, runF child)))
   where subtractSize maxSize size = liftA2 (-) <$> maxSize <*> (Just <$> size)
-        addSizeToPoint point (Size w h) = liftA2 (+) point (Point w h)
+        addSizeToPoint point = liftA2 (+) point . sizeExtent
 
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]
 renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . (,) (FittingState Full (pure 0) (pure Nothing))

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -85,7 +85,7 @@ renderingCoalgebra (state@FittingState{..}, rendering) = Cofree state id $ case 
       Inset by child -> Free id (InR (Inset by (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by)), runF child)))
       Offset by child -> Free id (InR (Offset by (FittingState alignment (liftA2 (+) origin by) (subtractSize maxSize (pointSize by)), runF child)))
       GetMaxSize -> Free ((,) state . runF) (InR GetMaxSize)
-      Align alignment child -> Free id (InR (Align alignment (state, runF child)))
+      Align alignment child -> Free id (InR (Align alignment (state { alignment = alignment }, runF child)))
   where subtractSize maxSize size = liftA2 (-) <$> maxSize <*> (Just <$> size)
         addSizeToPoint point (Size w h) = liftA2 (+) point (Point w h)
 

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -118,7 +118,7 @@ fittingCoalgebra (state@FittingState{..}, layout) = Cofree state id $ case runFr
     Inset by child -> Free id $ Inset by (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by)), run child)
     Offset by child -> Free id $ Offset by (FittingState alignment (liftA2 (+) origin by) (subtractSize maxSize (pointSize by)), run child)
     GetMaxSize -> Free ((,) state . run) GetMaxSize
-    Align alignment child -> Free id $ Align alignment (state, run child)
+    Align alignment child -> Free id $ Align alignment (state { alignment = alignment }, run child)
   where subtractSize maxSize size = liftA2 (-) <$> maxSize <*> (Just <$> size)
         addSizeToPoint point = liftA2 (+) point . sizeExtent
 

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -105,6 +105,9 @@ layoutRectanglesAlgebra = wrapAlgebra catMaybes (fmap Just) (collect layoutAlgeb
 
 type Fitting f a = Bidi f (Size a) (Alignment, Point a, Size (Maybe a))
 
+data FittingState a = FittingState { alignment :: !Alignment, origin :: !(Point a), maxSize :: !(Size (Maybe a)) }
+  deriving (Eq, Show)
+
 fitLayoutWith :: Real a => Algebra (Fitting (LayoutF a) a) b -> Size (Maybe a) -> Layout a (Size a) -> b
 fitLayoutWith algebra maxSize layout = hylo algebra fittingCoalgebra (Full, Point 0 0, maxSize, layout)
 

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -47,6 +47,12 @@ stack top bottom = do
   Size w2 h2 <- offset (Point 0 h1) bottom
   pure $ Size (max w1 w2) h2
 
+adjacent :: Real a => Layout a (Size a) -> Layout a (Size a) -> Layout a (Size a)
+adjacent left right = do
+  Size w1 h1 <- left
+  Size w2 h2 <- offset (Point w1 0) right
+  pure $ Size w2 (max h1 h2)
+
 alignLeft :: Layout a b -> Layout a b
 alignLeft = wrap . Align Leading
 

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -59,6 +59,9 @@ alignCentre = wrap . Align Centre
 alignFull :: Layout a b -> Layout a b
 alignFull = wrap . Align Full
 
+align :: Alignment -> Layout a b -> Layout a b
+align = (wrap .) . Align
+
 
 -- Evaluation
 

--- a/test/Test/Hspec/LeanCheck.hs
+++ b/test/Test/Hspec/LeanCheck.hs
@@ -12,14 +12,14 @@ prop :: (HasCallStack, Testable prop) => String -> prop -> Spec
 prop s = it s . Property
 
 data ShouldBe where
-  ShouldBe :: (Eq a, Show a) => a -> a -> ShouldBe
+  ShouldBe :: (Eq a, Show a) => CallStack -> a -> a -> ShouldBe
 
 infix 1 `shouldBe`
-shouldBe :: (Eq a, Show a) => a -> a -> ShouldBe
-shouldBe = ShouldBe
+shouldBe :: (Eq a, Show a, HasCallStack) => a -> a -> ShouldBe
+shouldBe = ShouldBe callStack
 
 instance Testable ShouldBe where
-  resultiers (ShouldBe actual expected) = fmap prependExpectation <$> resultiers (actual == expected)
+  resultiers (ShouldBe _ actual expected) = fmap prependExpectation <$> resultiers (actual == expected)
     where prependExpectation (strs, False) = ((showString "expected:\n" . shows expected . showString "\n but got:\n" . shows actual) "" : strs, False)
           prependExpectation other = other
 

--- a/test/UI/Layout/Spec.hs
+++ b/test/UI/Layout/Spec.hs
@@ -4,7 +4,7 @@ import Data.Maybe (fromMaybe, isJust)
 import Test.Hspec hiding (shouldBe)
 import Test.Hspec.LeanCheck
 import UI.Geometry
-import UI.Layout
+import UI.Layout hiding (FittingState(..))
 
 spec :: Spec
 spec = do

--- a/test/UI/Layout/Spec.hs
+++ b/test/UI/Layout/Spec.hs
@@ -69,6 +69,9 @@ spec = do
       [ Rect (Point 0 0) (Size (width a + width b) (max (height a) (height b)))
       , Rect (Point (width a) 0) (Size (width b) (max (height a) (height b))) ]
 
+    prop "alignment distributes over adjacency" $
+      \ a b c maxSize -> fitLayout (maxSize :: Size (Maybe Int)) (align a b `adjacent` align a c) `shouldBe` fitLayout maxSize (align a (b `adjacent` c))
+
   describe "alignLeft" $ do
     prop "minimizes its child’s width" $
       \ s -> (size <$> fitLayoutWith layoutRectanglesAlgebra (Just <$> (s + 2 :: Size Int)) (alignLeft (pure s))) `shouldBe`

--- a/test/UI/Layout/Spec.hs
+++ b/test/UI/Layout/Spec.hs
@@ -69,6 +69,15 @@ spec = do
       [ Rect (Point 0 0) (Size (width a + width b) (max (height a) (height b)))
       , Rect (Point (width a) 0) (Size (width b) (max (height a) (height b))) ]
 
+    prop "arranges aligned layouts" $
+      \ a b -> let maxHeight = max (height a) (height b)
+                   sumWidths = width (a + b) in
+        fitLayoutWith layoutRectanglesAlgebra (Size (Just sumWidths) (Just maxHeight) :: Size (Maybe Int)) (alignLeft (pure a) `adjacent` alignRight (pure b)) `shouldBe`
+        [ Rect (Point 0 0) (Size sumWidths maxHeight)
+        , Rect (Point 0 0) (Size sumWidths maxHeight)
+        , Rect (Point (width a) 0) (Size (width b) maxHeight)
+        , Rect (Point (width a) 0) (Size (width b) maxHeight) ]
+
     prop "alignment distributes over adjacency" $
       \ a b c maxSize -> fitLayout (maxSize :: Size (Maybe Int)) (align a b `adjacent` align a c) `shouldBe` fitLayout maxSize (align a (b `adjacent` c))
 

--- a/test/UI/Layout/Spec.hs
+++ b/test/UI/Layout/Spec.hs
@@ -57,6 +57,10 @@ spec = do
       [ Rect (Point 0 0) (Size (max (width a) (width b)) (height a + height b))
       , Rect (Point 0 (height a)) (Size (max (width a) (width b)) (height b)) ]
 
+  describe "adjacent" $ do
+    prop "takes the sum of its children’s widths" $
+      \ a b -> width (measureLayoutSize (adjacent (pure a) (pure (b :: Size Int)))) `shouldBe` width a + width b
+
   describe "alignLeft" $ do
     prop "minimizes its child’s width" $
       \ s -> (size <$> fitLayoutWith layoutRectanglesAlgebra (Just <$> (s + 2 :: Size Int)) (alignLeft (pure s))) `shouldBe`

--- a/test/UI/Layout/Spec.hs
+++ b/test/UI/Layout/Spec.hs
@@ -61,6 +61,9 @@ spec = do
     prop "takes the sum of its children’s widths" $
       \ a b -> width (measureLayoutSize (adjacent (pure a) (pure (b :: Size Int)))) `shouldBe` width a + width b
 
+    prop "takes the maximum of its children’s heights" $
+      \ a b -> height (measureLayoutSize (adjacent (pure (a :: Size Int)) (pure b))) `shouldBe` max (height a) (height b)
+
   describe "alignLeft" $ do
     prop "minimizes its child’s width" $
       \ s -> (size <$> fitLayoutWith layoutRectanglesAlgebra (Just <$> (s + 2 :: Size Int)) (alignLeft (pure s))) `shouldBe`

--- a/test/UI/Layout/Spec.hs
+++ b/test/UI/Layout/Spec.hs
@@ -64,6 +64,11 @@ spec = do
     prop "takes the maximum of its children’s heights" $
       \ a b -> height (measureLayoutSize (adjacent (pure (a :: Size Int)) (pure b))) `shouldBe` max (height a) (height b)
 
+    prop "arranges its second child after its first" $
+      \ a b -> fitLayoutWith layoutRectanglesAlgebra (pure Nothing) (adjacent (pure a) (pure (b :: Size Int))) `shouldBe`
+      [ Rect (Point 0 0) (Size (width a + width b) (max (height a) (height b)))
+      , Rect (Point (width a) 0) (Size (width b) (max (height a) (height b))) ]
+
   describe "alignLeft" $ do
     prop "minimizes its child’s width" $
       \ s -> (size <$> fitLayoutWith layoutRectanglesAlgebra (Just <$> (s + 2 :: Size Int)) (alignLeft (pure s))) `shouldBe`


### PR DESCRIPTION
Adding a constructor for placing layouts beside one another.

- [x] Add an adjacency constructor.
- [x] Test adjacent layouts.
- [x] Test adjacent aligned layouts.
- [x] Test the distributive law of alignment over adjacency:
  ```haskell
  (align a b) `adjacent` (align a c) = align a (b `adjacent` c)
  ```