### PR TITLE
Lift coalgebras over Sum

### DIFF
--- a/src/Control/Comonad/Cofree/Cofreer.hs
+++ b/src/Control/Comonad/Cofree/Cofreer.hs
@@ -9,8 +9,6 @@ module Control.Comonad.Cofree.Cofreer
 , unfold
 , hoistCofreer
 , hoistCofreerF
-, annotating
-, annotatingBidi
 , extract
 , unwrap
 ) where
@@ -52,13 +50,6 @@ hoistCofreer f = go
 
 hoistCofreerF :: (forall a. f a -> g a) -> CofreerF f b c -> CofreerF g b c
 hoistCofreerF f (Cofree a t r) = Cofree a t (f r)
-
-
-annotating :: Functor f => (f a -> a) -> f (Cofreer f a) -> Cofreer f a
-annotating algebra base = Cofreer (Cofree (algebra (extract <$> base)) id base)
-
-annotatingBidi :: Functor f => (CofreerF f b a -> a) -> CofreerF f b (Cofreer f a) -> Cofreer f a
-annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (tailF base))
 
 
 -- Instances

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -112,7 +112,9 @@ annotatingBidi :: Algebra (Bidi (FreerF f c) b) a -> Algebra (Bidi (FreerF f c) 
 annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (bidiF base))
 
 
-liftBidiCoalgebra :: (forall b x. seed -> (seed -> x -> b) -> f x -> FreerF f a b) -> Coalgebra (Bidi (FreerF f a) seed) (Bidi (FreerF f a) seed (Freer f a))
+type CoalgebraFragment functor seed pure = (forall b x. seed -> (seed -> x -> b) -> functor x -> FreerF functor pure b)
+
+liftBidiCoalgebra :: CoalgebraFragment f seed a -> Coalgebra (Bidi (FreerF f a) seed) (Bidi (FreerF f a) seed (Freer f a))
 liftBidiCoalgebra fragment bidi = setBidiF bidi $ case bidiF bidi of
   Pure a -> Pure a
   Free runF functor -> fragment (bidiState bidi) (\ state -> Bidi state . runFreer . runF) functor

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -118,3 +118,8 @@ liftBidiCoalgebra :: CoalgebraFragment f seed a -> Coalgebra (Bidi (FreerF f a) 
 liftBidiCoalgebra fragment bidi = setBidiF bidi $ case bidiF bidi of
   Pure a -> Pure a
   Free runF functor -> fragment (bidiState bidi) (\ state -> Bidi state . runFreer . runF) functor
+
+liftSumCoalgebra :: CoalgebraFragment l seed pure -> CoalgebraFragment r seed pure -> CoalgebraFragment (Sum l r) seed pure
+liftSumCoalgebra lf rf state run sum = case sum of
+  InL l -> hoistFreerF InL $ lf state run l
+  InR r -> hoistFreerF InR $ rf state run r

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -85,3 +85,10 @@ collect algebra c = wrapAlgebra ((++ fold c) . pure) head algebra c
 
 wrapAlgebra :: Functor f => (a -> b) -> (b -> a) -> Algebra f a -> Algebra f b
 wrapAlgebra into outOf algebra = into . algebra . fmap outOf
+
+
+annotating :: Functor f => (f a -> a) -> f (Cofreer f a) -> Cofreer f a
+annotating algebra base = Cofreer (Cofree (algebra (extract <$> base)) id base)
+
+annotatingBidi :: Functor f => (CofreerF f b a -> a) -> CofreerF f b (Cofreer f a) -> Cofreer f a
+annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (tailF base))

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -3,6 +3,7 @@ module Data.Functor.Algebraic where
 import Control.Comonad.Cofree.Cofreer
 import Control.Monad.Free.Freer
 import Data.Foldable (fold)
+import Data.Functor.Product
 import Data.Functor.Sum
 
 type Algebra functor result = functor result -> result
@@ -14,6 +15,9 @@ sumAlgebra :: Algebra l a -> Algebra r a -> Algebra (Sum l r) a
 sumAlgebra lAlgebra rAlgebra sum = case sum of
   InL l -> lAlgebra l
   InR r -> rAlgebra r
+
+productCoalgebra :: Coalgebra l a -> Coalgebra r a -> Coalgebra (Product l r) a
+productCoalgebra cl cr seed = Pair (cl seed) (cr seed)
 
 liftL :: Functor l => Freer l a -> Freer (Sum l r) a
 liftL (Freer f) = case f of

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -27,16 +27,6 @@ hoistSum ifl ifr sum = case sum of
   InR r -> InR (ifr r)
 
 
-liftL :: Functor l => Freer l a -> Freer (Sum l r) a
-liftL (Freer f) = case f of
-  Free t r -> wrapL (liftL . t <$> r)
-  Pure a -> pure a
-
-liftR :: Functor r => Freer r a -> Freer (Sum l r) a
-liftR  (Freer f) = case f of
-  Free t r -> wrapR (liftR . t <$> r)
-  Pure a -> pure a
-
 wrapL :: l (Freer (Sum l r) a) -> Freer (Sum l r) a
 wrapL = wrap . InL
 

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -23,8 +23,25 @@ sumAlgebra lAlgebra rAlgebra sum = case sum of
   InL l -> lAlgebra l
   InR r -> rAlgebra r
 
+sumCoalgebra :: (Functor l, Functor r) => Coalgebra l a -> Coalgebra r b -> Coalgebra (Sum l r) (Either a b)
+sumCoalgebra cl cr seed = case seed of
+  Left l -> Left <$> InL (cl l)
+  Right r -> Right <$> InR (cr r)
+
+sumFCoalgebra :: FCoalgebra l a -> FCoalgebra r b -> Coalgebra (Sum l r) (Either a b)
+sumFCoalgebra cl cr seed = case seed of
+  Left l -> InL (cl Left l)
+  Right r -> InR (cr Right r)
+
+
 productCoalgebra :: Coalgebra l a -> Coalgebra r a -> Coalgebra (Product l r) a
 productCoalgebra cl cr seed = Pair (cl seed) (cr seed)
+
+productAlgebra :: (Functor l, Functor r) => Algebra l a -> Algebra r b -> Algebra (Product l r) (a, b)
+productAlgebra al ar (Pair l r) = (al $ fst <$> l, ar $ snd <$> r)
+
+productFAlgebra :: FAlgebra l a -> FAlgebra r b -> Algebra (Product l r) (a, b)
+productFAlgebra al ar (Pair l r) = (al fst l, ar snd r)
 
 liftL :: Functor l => Freer l a -> Freer (Sum l r) a
 liftL (Freer f) = case f of

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -21,6 +21,11 @@ sumAlgebra lAlgebra rAlgebra sum = case sum of
   InL l -> lAlgebra l
   InR r -> rAlgebra r
 
+hoistSum :: (l a -> l' b) -> (r a -> r' b) -> Sum l r a -> Sum l' r' b
+hoistSum ifl ifr sum = case sum of
+  InL l -> InL (ifl l)
+  InR r -> InR (ifr r)
+
 
 liftL :: Functor l => Freer l a -> Freer (Sum l r) a
 liftL (Freer f) = case f of

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -90,5 +90,5 @@ wrapAlgebra into outOf algebra = into . algebra . fmap outOf
 annotating :: Functor f => Algebra f a -> Algebra f (Cofreer f a)
 annotating algebra base = Cofreer (Cofree (algebra (extract <$> base)) id base)
 
-annotatingBidi :: Functor f => (CofreerF f b a -> a) -> CofreerF f b (Cofreer f a) -> Cofreer f a
+annotatingBidi :: Functor f => Algebra (CofreerF f b) a -> Algebra (CofreerF f b) (Cofreer f a)
 annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (tailF base))

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -44,6 +44,12 @@ distSumFreerF s = case s of
     Pure a -> Pure a
     Free run f -> Free run (InR f)
 
+-- | Distributive law for Sum over CofreerF.
+distSumCofreerF :: Sum (CofreerF f a) (CofreerF g a) c -> CofreerF (Sum f g) a c
+distSumCofreerF s = case s of
+  InL (Cofree a t r) -> Cofree a t (InL r)
+  InR (Cofree a t r) -> Cofree a t (InR r)
+
 
 productCoalgebra :: Coalgebra l a -> Coalgebra r a -> Coalgebra (Product l r) a
 productCoalgebra cl cr seed = Pair (cl seed) (cr seed)

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -16,8 +16,6 @@ type FAlgebra functor result = forall x. (x -> result) -> functor x -> result
 -- | A coalgebra taking a function to apply to values inside the functor.
 type FCoalgebra functor seed = forall x. (seed -> x) -> seed -> functor x
 
-type Bidi functor pure = CofreerF (FreerF functor pure)
-
 sumAlgebra :: Algebra l a -> Algebra r a -> Algebra (Sum l r) a
 sumAlgebra lAlgebra rAlgebra sum = case sum of
   InL l -> lAlgebra l

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -90,6 +90,11 @@ wrapAlgebra into outOf algebra = into . algebra . fmap outOf
 annotating :: Functor f => Algebra f a -> Algebra f (Cofreer f a)
 annotating algebra base = Cofreer (Cofree (algebra (extract <$> base)) id base)
 
+coannotating :: Functor f => Coalgebra f a -> Coalgebra f (Freer f a)
+coannotating coalgebra seed = case runFreer seed of
+  Pure a -> pure <$> coalgebra a
+  Free run f -> run <$> f
+
 annotatingF :: FAlgebra f a -> FAlgebra f (Cofreer f a)
 annotatingF algebra f base = Cofreer (Cofree (algebra (extract . f) base) f base)
 

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -17,12 +17,12 @@ type FAlgebra functor result = forall x. (x -> result) -> functor x -> result
 type FCoalgebra functor seed = forall x. (seed -> x) -> seed -> functor x
 
 -- | A datatype for use as the interim structure in bidirectional computations represented as hylomorphisms.
-data Bidi f a b c = Bidi
+data Bidi f a b = Bidi
   { bidiState :: a
-  , bidiF :: FreerF f b c }
+  , bidiF :: f b }
   deriving (Eq, Foldable, Functor, Show)
 
-setBidiF :: Bidi f a b c -> FreerF f b d -> Bidi f a b d
+setBidiF :: Bidi f a b -> f c -> Bidi f a c
 setBidiF bidi a = bidi { bidiF = a }
 
 
@@ -108,5 +108,5 @@ coannotating coalgebra seed = case runFreer seed of
 annotatingF :: FAlgebra f a -> FAlgebra f (Cofreer f a)
 annotatingF algebra f base = Cofreer (Cofree (algebra (extract . f) base) f base)
 
-annotatingBidi :: Algebra (Bidi f b c) a -> Algebra (Bidi f b c) (Cofreer (FreerF f c) a)
+annotatingBidi :: Algebra (Bidi (FreerF f c) b) a -> Algebra (Bidi (FreerF f c) b) (Cofreer (FreerF f c) a)
 annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (bidiF base))

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -16,7 +16,7 @@ type FAlgebra functor result = forall x. (x -> result) -> functor x -> result
 -- | A coalgebra taking a function to apply to values inside the functor.
 type FCoalgebra functor seed = forall x. (seed -> x) -> seed -> functor x
 
-type Bidi functor pure state = CofreerF (FreerF functor pure) state
+type Bidi functor pure = CofreerF (FreerF functor pure)
 
 sumAlgebra :: Algebra l a -> Algebra r a -> Algebra (Sum l r) a
 sumAlgebra lAlgebra rAlgebra sum = case sum of

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -22,6 +22,9 @@ data Bidi f a b c = Bidi
   , bidiF :: FreerF f b c }
   deriving (Eq, Foldable, Functor, Show)
 
+setBidiF :: Bidi f a b c -> FreerF f b c -> Bidi f a b c
+setBidiF bidi a = bidi { bidiF = a }
+
 
 sumAlgebra :: Algebra l a -> Algebra r a -> Algebra (Sum l r) a
 sumAlgebra lAlgebra rAlgebra sum = case sum of

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -22,7 +22,7 @@ data Bidi f a b c = Bidi
   , bidiF :: FreerF f b c }
   deriving (Eq, Foldable, Functor, Show)
 
-setBidiF :: Bidi f a b c -> FreerF f b c -> Bidi f a b c
+setBidiF :: Bidi f a b c -> FreerF f b d -> Bidi f a b d
 setBidiF bidi a = bidi { bidiF = a }
 
 

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -15,9 +15,6 @@ data Bidi f a b = Bidi
   , bidiF :: f b }
   deriving (Eq, Foldable, Functor, Show)
 
-setBidiF :: Bidi f a b -> f c -> Bidi f a c
-setBidiF bidi a = bidi { bidiF = a }
-
 
 sumAlgebra :: Algebra l a -> Algebra r a -> Algebra (Sum l r) a
 sumAlgebra lAlgebra rAlgebra sum = case sum of
@@ -69,9 +66,9 @@ annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (b
 type CoalgebraFragment functor seed pure = (forall b x. seed -> (seed -> x -> b) -> functor x -> FreerF functor pure b)
 
 liftBidiCoalgebra :: CoalgebraFragment f seed a -> Coalgebra (Bidi (FreerF f a) seed) (Bidi (FreerF f a) seed (Freer f a))
-liftBidiCoalgebra fragment bidi = setBidiF bidi $ case bidiF bidi of
+liftBidiCoalgebra fragment (Bidi state f) = Bidi state $ case f of
   Pure a -> Pure a
-  Free runF functor -> fragment (bidiState bidi) (\ state -> Bidi state . runFreer . runF) functor
+  Free runF functor -> fragment state (\ state -> Bidi state . runFreer . runF) functor
 
 liftSumCoalgebra :: CoalgebraFragment l seed pure -> CoalgebraFragment r seed pure -> CoalgebraFragment (Sum l r) seed pure
 liftSumCoalgebra lf rf state run sum = case sum of

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -87,7 +87,7 @@ wrapAlgebra :: Functor f => (a -> b) -> (b -> a) -> Algebra f a -> Algebra f b
 wrapAlgebra into outOf algebra = into . algebra . fmap outOf
 
 
-annotating :: Functor f => (f a -> a) -> f (Cofreer f a) -> Cofreer f a
+annotating :: Functor f => Algebra f a -> Algebra f (Cofreer f a)
 annotating algebra base = Cofreer (Cofree (algebra (extract <$> base)) id base)
 
 annotatingBidi :: Functor f => (CofreerF f b a -> a) -> CofreerF f b (Cofreer f a) -> Cofreer f a

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -90,5 +90,8 @@ wrapAlgebra into outOf algebra = into . algebra . fmap outOf
 annotating :: Functor f => Algebra f a -> Algebra f (Cofreer f a)
 annotating algebra base = Cofreer (Cofree (algebra (extract <$> base)) id base)
 
+annotatingF :: FAlgebra f a -> FAlgebra f (Cofreer f a)
+annotatingF algebra f base = Cofreer (Cofree (algebra (extract . f) base) f base)
+
 annotatingBidi :: Functor f => Algebra (CofreerF f b) a -> Algebra (CofreerF f b) (Cofreer f a)
 annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (tailF base))

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -16,6 +16,13 @@ type FAlgebra functor result = forall x. (x -> result) -> functor x -> result
 -- | A coalgebra taking a function to apply to values inside the functor.
 type FCoalgebra functor seed = forall x. (seed -> x) -> seed -> functor x
 
+-- | A datatype for use as the interim structure in bidirectional computations represented as hylomorphisms.
+data Bidi f a b c = Bidi
+  { bidiState :: a
+  , bidiF :: FreerF f b c }
+  deriving (Eq, Foldable, Functor, Show)
+
+
 sumAlgebra :: Algebra l a -> Algebra r a -> Algebra (Sum l r) a
 sumAlgebra lAlgebra rAlgebra sum = case sum of
   InL l -> lAlgebra l

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -34,6 +34,17 @@ sumFCoalgebra cl cr seed = case seed of
   Right r -> InR (cr Right r)
 
 
+-- | Distributive law for Sum over FreerF.
+distSumFreerF :: Sum (FreerF f a) (FreerF g a) c -> FreerF (Sum f g) a c
+distSumFreerF s = case s of
+  InL l -> case l of
+    Pure a -> Pure a
+    Free run f -> Free run (InL f)
+  InR r -> case r of
+    Pure a -> Pure a
+    Free run f -> Free run (InR f)
+
+
 productCoalgebra :: Coalgebra l a -> Coalgebra r a -> Coalgebra (Product l r) a
 productCoalgebra cl cr seed = Pair (cl seed) (cr seed)
 

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -105,5 +105,5 @@ coannotating coalgebra seed = case runFreer seed of
 annotatingF :: FAlgebra f a -> FAlgebra f (Cofreer f a)
 annotatingF algebra f base = Cofreer (Cofree (algebra (extract . f) base) f base)
 
-annotatingBidi :: Functor f => Algebra (CofreerF f b) a -> Algebra (CofreerF f b) (Cofreer f a)
-annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (tailF base))
+annotatingBidi :: Algebra (Bidi f b c) a -> Algebra (Bidi f b c) (Cofreer (FreerF f c) a)
+annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (bidiF base))

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE RankNTypes #-}
 module Data.Functor.Algebraic where
 
 import Control.Comonad.Cofree.Cofreer
@@ -8,6 +9,12 @@ import Data.Functor.Sum
 
 type Algebra functor result = functor result -> result
 type Coalgebra functor seed = seed -> functor seed
+
+-- | An algebra taking a function to apply to values inside the functor.
+type FAlgebra functor result = forall x. (x -> result) -> functor x -> result
+
+-- | A coalgebra taking a function to apply to values inside the functor.
+type FCoalgebra functor seed = forall x. (seed -> x) -> seed -> functor x
 
 type Bidi functor pure state = CofreerF (FreerF functor pure) state
 

--- a/src/Data/Functor/Algebraic.hs
+++ b/src/Data/Functor/Algebraic.hs
@@ -110,3 +110,9 @@ annotatingF algebra f base = Cofreer (Cofree (algebra (extract . f) base) f base
 
 annotatingBidi :: Algebra (Bidi (FreerF f c) b) a -> Algebra (Bidi (FreerF f c) b) (Cofreer (FreerF f c) a)
 annotatingBidi algebra base = Cofreer (Cofree (algebra (extract <$> base)) id (bidiF base))
+
+
+liftBidiCoalgebra :: (forall b x. seed -> (seed -> x -> b) -> f x -> FreerF f a b) -> Coalgebra (Bidi (FreerF f a) seed) (Bidi (FreerF f a) seed (Freer f a))
+liftBidiCoalgebra fragment bidi = setBidiF bidi $ case bidiF bidi of
+  Pure a -> Pure a
+  Free runF functor -> fragment (bidiState bidi) (\ state -> Bidi state . runFreer . runF) functor

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -68,13 +68,13 @@ renderingRectAlgebra (Bidi a@(FittingState _ origin _) r) = case r of
 drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (Drawing a (Size a)))
 drawingCoalgebra = liftBidiCoalgebra drawingFCoalgebra
 
-drawingFCoalgebra :: FittingState a -> (FittingState a -> x -> b) -> DrawingF a x -> FreerF (DrawingF a) (Size a) b
+drawingFCoalgebra :: CoalgebraFragment (DrawingF a) (FittingState a) (Size a)
 drawingFCoalgebra state run = Free (run state)
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (RenderingF a) a (Rendering a (Size a)))
 renderingCoalgebra = liftBidiCoalgebra renderingFCoalgebra
 
-renderingFCoalgebra :: Real a => FittingState a -> (FittingState a -> x -> b) -> RenderingF a x -> FreerF (RenderingF a) (Size a) b
+renderingFCoalgebra :: Real a => CoalgebraFragment (RenderingF a) (FittingState a) (Size a)
 renderingFCoalgebra state run renderingF = case renderingF of
   InL drawingF -> hoistFreerF InL $ drawingFCoalgebra state run drawingF
   InR layoutF -> hoistFreerF InR $ layoutFCoalgebra state run layoutF

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleInstances, GADTs, RecordWildCards #-}
+{-# LANGUAGE FlexibleInstances, GADTs #-}
 module UI.Drawing
 ( Shape(..)
 , Colour(..)
@@ -69,11 +69,11 @@ drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (
 drawingCoalgebra bidi = setBidiF bidi . runFreer <$> bidi
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (RenderingF a) a (Rendering a (Size a)))
-renderingCoalgebra (Bidi state@FittingState{..} rendering) = Bidi state $ case rendering of
+renderingCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
   Pure size -> Pure size
   Free runF renderingF -> case renderingF of
-    InL _ -> Bidi state . runFreer <$> rendering
-    InR layoutF -> hoistFreerF InR $ layoutFCoalgebra state (\ state -> Bidi state . runFreer . runF) layoutF
+    InL _ -> setBidiF bidi . runFreer <$> bidiF bidi
+    InR layoutF -> hoistFreerF InR $ layoutFCoalgebra (bidiState bidi) (\ state -> Bidi state . runFreer . runF) layoutF
 
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]
 renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . Bidi (FittingState Full (pure 0) (pure Nothing)) . runFreer

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -75,7 +75,7 @@ renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (R
 renderingCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
   Pure size -> Pure size
   Free runF renderingF -> case renderingF of
-    InL _ -> setBidiF bidi . runFreer <$> bidiF bidi
+    InL drawingF -> hoistFreerF InL $ drawingFCoalgebra (bidiState bidi) (\ state -> Bidi state . runFreer . runF) drawingF
     InR layoutF -> hoistFreerF InR $ layoutFCoalgebra (bidiState bidi) (\ state -> Bidi state . runFreer . runF) layoutF
 
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -66,12 +66,12 @@ renderingRectAlgebra (Fitting a@(FittingState _ origin _) r) = case r of
     InL drawing -> drawingRectAlgebra (Fitting a (Free runF drawing))
     InR layout -> fromMaybe (Rect (pure 0) (pure 0)) (layoutAlgebra (Fitting a (Free (Just . runF) layout)))
 
-drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (FittingState a, Drawing a (Size a))
-drawingCoalgebra (state, drawing) = Fitting state $ case runFreer drawing of
+drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (Size a))
+drawingCoalgebra (Fitting state drawing) = Fitting state $ case drawing of
   Pure size -> Pure size
-  Free runF drawing -> case drawing of
-    Text size string -> Free ((,) state . runF) (Text size string)
-    Clip size child -> Free id (Clip size (state, runF child))
+  Free runF drawingF -> Free (Fitting state . Pure . runF) $ case drawingF of
+    Text size string -> Text size string
+    Clip size child -> Clip size child
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (FittingState a, Rendering a (Size a))
 renderingCoalgebra (state@FittingState{..}, rendering) = Fitting state $ case runFreer rendering of

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -79,6 +79,11 @@ renderingCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
     InR layoutF -> hoistFreerF InR $ layoutFCoalgebra (bidiState bidi) run layoutF
     where run state = Bidi state . runFreer . runF
 
+renderingFCoalgebra :: Real a => FittingState a -> (FittingState a -> x -> b) -> RenderingF a x -> FreerF (RenderingF a) (Size a) b
+renderingFCoalgebra state run renderingF = case renderingF of
+  InL drawingF -> hoistFreerF InL $ drawingFCoalgebra state run drawingF
+  InR layoutF -> hoistFreerF InR $ layoutFCoalgebra state run layoutF
+
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]
 renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . Bidi (FittingState Full (pure 0) (pure Nothing)) . runFreer
 

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -69,17 +69,13 @@ renderingRectAlgebra (Bidi a@(FittingState _ origin _) r) = case r of
 drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (Drawing a (Size a)))
 drawingCoalgebra (Bidi state drawing) = Bidi state $ case drawing of
   Pure size -> Pure size
-  Free runF drawingF -> Free (Bidi state . runFreer . runF) $ case drawingF of
-    Text size string -> Text size string
-    Clip size child -> Clip size child
+  Free runF drawingF -> Free (Bidi state . runFreer . runF) drawingF
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (RenderingF a) a (Rendering a (Size a)))
 renderingCoalgebra (Bidi state@FittingState{..} rendering) = Bidi state $ case rendering of
   Pure size -> Pure size
   Free runF renderingF -> case renderingF of
-    InL drawingF -> Free (Bidi state . runFreer . runF) . InL $ case drawingF of
-      Text size string -> Text size string
-      Clip size child -> Clip size child
+    InL drawingF -> Free (Bidi state . runFreer . runF) (InL drawingF)
     InR layoutF -> case layoutF of
       Inset by child -> wrapState (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by))) $ Inset by child
       Offset by child -> wrapState (FittingState alignment (liftA2 (+) origin by) (subtractSize maxSize (pointSize by))) $ Offset by child

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -9,7 +9,6 @@ module UI.Drawing
 , text
 , clip
 , drawingRectAlgebra
-, drawingRectanglesAlgebra
 , renderingRectAlgebra
 , drawingCoalgebra
 , renderingCoalgebra
@@ -54,9 +53,6 @@ drawingRectAlgebra (Bidi (FittingState _ origin _) r) = Rect origin $ case r of
   Free runF drawing -> case drawing of
     Text maxSize s -> size (runF (measureText (width maxSize) s))
     Clip size _ -> size
-
-drawingRectanglesAlgebra :: Real a => Algebra (Fitting (DrawingF a) a) [Rect a]
-drawingRectanglesAlgebra = collect drawingRectAlgebra
 
 renderingRectAlgebra :: Real a => Algebra (Fitting (RenderingF a) a) (Rect a)
 renderingRectAlgebra (Bidi a@(FittingState _ origin _) r) = case r of

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -75,8 +75,9 @@ renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (R
 renderingCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
   Pure size -> Pure size
   Free runF renderingF -> case renderingF of
-    InL drawingF -> hoistFreerF InL $ drawingFCoalgebra (bidiState bidi) (\ state -> Bidi state . runFreer . runF) drawingF
-    InR layoutF -> hoistFreerF InR $ layoutFCoalgebra (bidiState bidi) (\ state -> Bidi state . runFreer . runF) layoutF
+    InL drawingF -> hoistFreerF InL $ drawingFCoalgebra (bidiState bidi) run drawingF
+    InR layoutF -> hoistFreerF InR $ layoutFCoalgebra (bidiState bidi) run layoutF
+    where run state = Bidi state . runFreer . runF
 
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]
 renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . Bidi (FittingState Full (pure 0) (pure Nothing)) . runFreer

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -66,7 +66,7 @@ renderingRectAlgebra (Bidi a@(FittingState _ origin _) r) = case r of
     InR layout -> fromMaybe (Rect (pure 0) (pure 0)) (layoutAlgebra (Bidi a (Free (Just . runF) layout)))
 
 drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (Drawing a (Size a)))
-drawingCoalgebra bidi = setBidiF bidi . runFreer <$> bidi
+drawingCoalgebra = liftBidiCoalgebra drawingFCoalgebra
 
 drawingFCoalgebra :: FittingState a -> (FittingState a -> x -> b) -> DrawingF a x -> FreerF (DrawingF a) (Size a) b
 drawingFCoalgebra state run = Free (run state)

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -72,12 +72,7 @@ drawingFCoalgebra :: CoalgebraFragment (DrawingF a) (FittingState a) (Size a)
 drawingFCoalgebra state run = Free (run state)
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (RenderingF a) a (Rendering a (Size a)))
-renderingCoalgebra = liftBidiCoalgebra renderingFCoalgebra
-
-renderingFCoalgebra :: Real a => CoalgebraFragment (RenderingF a) (FittingState a) (Size a)
-renderingFCoalgebra state run renderingF = case renderingF of
-  InL drawingF -> hoistFreerF InL $ drawingFCoalgebra state run drawingF
-  InR layoutF -> hoistFreerF InR $ layoutFCoalgebra state run layoutF
+renderingCoalgebra = liftBidiCoalgebra (liftSumCoalgebra drawingFCoalgebra layoutFCoalgebra)
 
 renderingRects :: Real a => Rendering a (Size a) -> [Rect a]
 renderingRects = hylo (collect renderingRectAlgebra) renderingCoalgebra . Bidi (FittingState Full (pure 0) (pure Nothing)) . runFreer

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -57,9 +57,7 @@ drawingRectAlgebra (Bidi (FittingState _ origin _) r) = Rect origin <$> case r o
 renderingRectAlgebra :: Real a => Algebra (Fitting (RenderingF a) a) (Maybe (Rect a))
 renderingRectAlgebra (Bidi a@(FittingState _ origin _) r) = case r of
   Pure size -> Just (Rect origin size)
-  Free runF sum -> case sum of
-    InL drawing -> drawingRectAlgebra (Bidi a (Free runF drawing))
-    InR layout -> layoutAlgebra (Bidi a (Free runF layout))
+  Free runF sum -> sumAlgebra drawingRectAlgebra layoutAlgebra $ hoistSum (Bidi a . Free runF) (Bidi a . Free runF) sum
 
 drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (Drawing a (Size a)))
 drawingCoalgebra = liftBidiCoalgebra drawingFCoalgebra

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -72,12 +72,7 @@ drawingFCoalgebra :: FittingState a -> (FittingState a -> x -> b) -> DrawingF a 
 drawingFCoalgebra state run = Free (run state)
 
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (RenderingF a) a (Rendering a (Size a)))
-renderingCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
-  Pure size -> Pure size
-  Free runF renderingF -> case renderingF of
-    InL drawingF -> hoistFreerF InL $ drawingFCoalgebra (bidiState bidi) run drawingF
-    InR layoutF -> hoistFreerF InR $ layoutFCoalgebra (bidiState bidi) run layoutF
-    where run state = Bidi state . runFreer . runF
+renderingCoalgebra = liftBidiCoalgebra renderingFCoalgebra
 
 renderingFCoalgebra :: Real a => FittingState a -> (FittingState a -> x -> b) -> RenderingF a x -> FreerF (RenderingF a) (Size a) b
 renderingFCoalgebra state run renderingF = case renderingF of

--- a/src/UI/Drawing.hs
+++ b/src/UI/Drawing.hs
@@ -68,6 +68,9 @@ renderingRectAlgebra (Bidi a@(FittingState _ origin _) r) = case r of
 drawingCoalgebra :: Coalgebra (Fitting (DrawingF a) a) (Fitting (DrawingF a) a (Drawing a (Size a)))
 drawingCoalgebra bidi = setBidiF bidi . runFreer <$> bidi
 
+drawingFCoalgebra :: FittingState a -> (FittingState a -> x -> b) -> DrawingF a x -> FreerF (DrawingF a) (Size a) b
+drawingFCoalgebra state run = Free (run state)
+
 renderingCoalgebra :: Real a => Coalgebra (Fitting (RenderingF a) a) (Fitting (RenderingF a) a (Rendering a (Size a)))
 renderingCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
   Pure size -> Pure size

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -118,10 +118,10 @@ data FittingState a = FittingState { alignment :: !Alignment, origin :: !(Point 
   deriving (Eq, Show)
 
 fitLayoutWith :: Real a => Algebra (Fitting (LayoutF a) a) b -> Size (Maybe a) -> Layout a (Size a) -> b
-fitLayoutWith algebra maxSize layout = hylo algebra fittingCoalgebra (FittingState Full (Point 0 0) maxSize, layout)
+fitLayoutWith algebra maxSize layout = hylo algebra layoutCoalgebra (FittingState Full (Point 0 0) maxSize, layout)
 
-fittingCoalgebra :: Real a => Coalgebra (Fitting (LayoutF a) a) (FittingState a, Layout a (Size a))
-fittingCoalgebra (state@FittingState{..}, layout) = Cofree state id $ case runFreer layout of
+layoutCoalgebra :: Real a => Coalgebra (Fitting (LayoutF a) a) (FittingState a, Layout a (Size a))
+layoutCoalgebra (state@FittingState{..}, layout) = Cofree state id $ case runFreer layout of
   Pure size -> Pure size
   Free run layout -> case layout of
     Inset by child -> Free id $ Inset by (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by)), run child)

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -118,9 +118,7 @@ fitLayoutWith :: Real a => Algebra (Fitting (LayoutF a) a) b -> Size (Maybe a) -
 fitLayoutWith algebra maxSize layout = hylo algebra layoutCoalgebra (Bidi (FittingState Full (Point 0 0) maxSize) (runFreer layout))
 
 layoutCoalgebra :: Real a => Coalgebra (Fitting (LayoutF a) a) (Fitting (LayoutF a) a (Layout a (Size a)))
-layoutCoalgebra bidi = setBidiF bidi $ case bidiF bidi of
-  Pure size -> Pure size
-  Free runF layoutF -> layoutFCoalgebra (bidiState bidi) (\ state -> Bidi state . runFreer . runF) layoutF
+layoutCoalgebra = liftBidiCoalgebra layoutFCoalgebra
 
 layoutFCoalgebra :: Real a => FittingState a -> (FittingState a -> x -> b) -> LayoutF a x -> FreerF (LayoutF a) (Size a) b
 layoutFCoalgebra state@FittingState{..} run layoutF = case layoutF of

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -84,9 +84,6 @@ measureLayout = fromMaybe (Rect (Point 0 0) (Size 0 0)) . fitLayout (pure Nothin
 fitLayout :: Real a => Size (Maybe a) -> Layout a (Size a) -> Maybe (Rect a)
 fitLayout = fitLayoutWith layoutAlgebra
 
-fitLayoutAndAnnotate :: Real a => Size (Maybe a) -> Layout a (Size a) -> ALayout a (Size a) (Maybe (Rect a))
-fitLayoutAndAnnotate = fitLayoutWith (annotatingBidi layoutAlgebra)
-
 layoutAlgebra :: Real a => Algebra (Fitting (LayoutF a) a) (Maybe (Rect a))
 layoutAlgebra (Cofree FittingState{..} runC layout) = case layout of
   Pure size | maxSize `encloses` size -> Just $ case alignment of

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -85,7 +85,7 @@ fitLayout :: Real a => Size (Maybe a) -> Layout a (Size a) -> Maybe (Rect a)
 fitLayout = fitLayoutWith layoutAlgebra
 
 layoutAlgebra :: Real a => Algebra (Fitting (LayoutF a) a) (Maybe (Rect a))
-layoutAlgebra (Cofree FittingState{..} runC layout) = case layout of
+layoutAlgebra (Fitting FittingState{..} layout) = case layout of
   Pure size | maxSize `encloses` size -> Just $ case alignment of
     Leading -> Rect origin minSize
     Trailing -> Rect origin { x = x origin + widthDiff} minSize
@@ -95,11 +95,11 @@ layoutAlgebra (Cofree FittingState{..} runC layout) = case layout of
           fullSize = fromMaybe <$> size <*> maxSize
           widthDiff = maybe 0 (+ negate (width size)) (width maxSize)
   Free runF layout -> case layout of
-    Inset by child -> Rect origin . (2 * by +) . size <$> runC (runF child)
-    Offset by child -> Rect origin . (pointSize by +) . size <$> runC (runF child)
-    GetMaxSize -> runC (runF maxSize)
+    Inset by child -> Rect origin . (2 * by +) . size <$> runF child
+    Offset by child -> Rect origin . (pointSize by +) . size <$> runF child
+    GetMaxSize -> runF maxSize
     Align _ child -> do
-      Rect _ size <- runC (runF child)
+      Rect _ size <- runF child
       pure $ Rect origin (fromMaybe <$> size <*> maxSize)
   _ -> Nothing
   where maxSize `encloses` size = and (maybe (const True) (>=) <$> maxSize <*> size)
@@ -109,7 +109,8 @@ layoutRectanglesAlgebra :: Real a => Algebra (Fitting (LayoutF a) a) [Rect a]
 layoutRectanglesAlgebra = wrapAlgebra catMaybes (fmap Just) (collect layoutAlgebra)
 
 
-type Fitting f a = CofreerF (FreerF f (Size a)) (FittingState a)
+data Fitting f a b = Fitting (FittingState a) (FreerF f (Size a) b)
+  deriving (Foldable, Functor)
 
 data FittingState a = FittingState { alignment :: !Alignment, origin :: !(Point a), maxSize :: !(Size (Maybe a)) }
   deriving (Eq, Show)
@@ -118,7 +119,7 @@ fitLayoutWith :: Real a => Algebra (Fitting (LayoutF a) a) b -> Size (Maybe a) -
 fitLayoutWith algebra maxSize layout = hylo algebra layoutCoalgebra (FittingState Full (Point 0 0) maxSize, layout)
 
 layoutCoalgebra :: Real a => Coalgebra (Fitting (LayoutF a) a) (FittingState a, Layout a (Size a))
-layoutCoalgebra (state@FittingState{..}, layout) = Cofree state id $ case runFreer layout of
+layoutCoalgebra (state@FittingState{..}, layout) = Fitting state $ case runFreer layout of
   Pure size -> Pure size
   Free run layout -> case layout of
     Inset by child -> Free id $ Inset by (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by)), run child)

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -120,7 +120,7 @@ fitLayoutWith algebra maxSize layout = hylo algebra layoutCoalgebra (Bidi (Fitti
 layoutCoalgebra :: Real a => Coalgebra (Fitting (LayoutF a) a) (Fitting (LayoutF a) a (Layout a (Size a)))
 layoutCoalgebra = liftBidiCoalgebra layoutFCoalgebra
 
-layoutFCoalgebra :: Real a => FittingState a -> (FittingState a -> x -> b) -> LayoutF a x -> FreerF (LayoutF a) (Size a) b
+layoutFCoalgebra :: Real a => CoalgebraFragment (LayoutF a) (FittingState a) (Size a)
 layoutFCoalgebra state@FittingState{..} run layoutF = case layoutF of
   Inset by child -> wrapState (FittingState alignment (addSizeToPoint origin by) (subtractSize maxSize (2 * by))) $ Inset by child
   Offset by child -> wrapState (FittingState alignment (liftA2 (+) origin by) (subtractSize maxSize (pointSize by))) $ Offset by child

--- a/src/UI/Layout.hs
+++ b/src/UI/Layout.hs
@@ -112,7 +112,7 @@ layoutRectanglesAlgebra :: Real a => Algebra (Fitting (LayoutF a) a) [Rect a]
 layoutRectanglesAlgebra = wrapAlgebra catMaybes (fmap Just) (collect layoutAlgebra)
 
 
-type Fitting f a = Bidi f (Size a) (FittingState a)
+type Fitting f a = CofreerF (FreerF f (Size a)) (FittingState a)
 
 data FittingState a = FittingState { alignment :: !Alignment, origin :: !(Point a), maxSize :: !(Size (Maybe a)) }
   deriving (Eq, Show)


### PR DESCRIPTION
`renderingCoalgebra` in `src/UI/Drawing.hs` duplicates both `layoutCoalgebra` and `drawingCoalgebra`. This PR is an attempt to avoid that (substantial) duplication, leaving `renderingCoalgebra` as a simple composite construction much like `renderingAlgebra` is.

It is possible to lift coalgebras on `f` and `g` into coalgebras on `Sum f g`s with e.g. a little `Either` sprinkled on the seeds. However, this gets substantially trickier under the bidirectional setting these coalgebras are intended to be used for. Essentially, the functor being operated under in a given computation (i.e. `DrawingF`, `LayoutF`, `RenderingF`) occurs in both positive and negative positions. It’s trivial to hoist the result of `drawingCoalgebra` into `InL`, but `drawingCoalgebra` expects to receive values in (presently) `FreerF (DrawingF a) (Size a) (Drawing a (Size a))`; and there is in general no suitable function of type `Rendering a (Size a) -> Drawing a (Size a)`.

It may be possible to split `drawingCoalgebra` from taking/producing `FreerF (DrawingF a) (Size a) (Drawing a (Size a))` into one over `DrawingF a b`, and another over `FreerF f a b` given some appropriate algebra `f b -> b`. That might enable us to compose both `renderingCoalgebra` and `drawingCoalgebra` from the same former case, while also allowing us to handle `Pure` values once and only once.